### PR TITLE
Onejar maven plugin is not available from googlecode any more.

### DIFF
--- a/maddash-server/pom.xml
+++ b/maddash-server/pom.xml
@@ -22,14 +22,6 @@
       </repository>
   </repositories>
    
-  <!-- puts all code & libraries in one jar -->
-  <pluginRepositories>
-      <pluginRepository>
-          <id>onejar-maven-plugin.googlecode.com</id>
-          <url>http://onejar-maven-plugin.googlecode.com/svn/mavenrepo</url>
-      </pluginRepository>
-  </pluginRepositories>
-    
   <dependencies>
     <!-- netlogger -->
     <dependency>
@@ -123,9 +115,9 @@
         <plugins>
             <!-- puts all code & libraries in one jar -->
             <plugin>
-                <groupId>org.dstovall</groupId>
+                <groupId>com.jolira</groupId>
                 <artifactId>onejar-maven-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>1.4.4</version>
                 <executions>
                     <execution>
                         <configuration>


### PR DESCRIPTION
The attached pull request takes it from maven-central, see https://github.com/jolira/onejar-maven-plugin